### PR TITLE
Change jq filter to allow installing dev versions

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -20,7 +20,9 @@ install() {
     versionListUrl="https://storage.googleapis.com/flutter_infra/releases/releases_linux.json"
   fi
   
-  local filePath=$(curl -sL "${versionListUrl}" | "${jq}" -r --arg VERSION "${ASDF_INSTALL_VERSION}" '.releases | map({version: (.version[1:] + "-" + .channel), url: (.archive)}) | map(select(.version == $VERSION)) | .[].url')
+  local escapedInstallVersion=$(echo $ASDF_INSTALL_VERSION | sed 's/\./\\\./g;s/\+/\\\+/g')
+
+  local filePath=$(curl -sL "${versionListUrl}" | "${jq}" -r --arg VERSION "${escapedInstallVersion}" '.releases[] | select((.version + "-" + .channel) | test("^v?" + $VERSION)) | .archive')
 
   if [ -z "${filePath}" ]; then
     echo "Cannot find the download url for the version: ${ASDF_INSTALL_VERSION}"


### PR DESCRIPTION
Some dev versions don't start with a `v` character, so the previous filter was simply removing the major version number.

Examples:
```json
{
  "releases": [
    {
      "hash": "8f7327f83a3e094285163ae402c6f94190fc1674",
      "channel": "dev",
      "version": "1.18.0-dev.4.0",
      "release_date": "2020-04-07T16:30:52.454830Z",
      "archive": "dev/macos/flutter_macos_1.18.0-dev.4.0-dev.zip",
      "sha256": "e71646659a06fe3a6203c15817ff7299825981b998f14cd344ac9877867f3957"
    },
    {
      "hash": "de1e5729165b61829a8fa7c41b449c6c7ad74c84",
      "channel": "dev",
      "version": "1.18.0-dev.3.0",
      "release_date": "2020-04-07T04:17:19.757100Z",
      "archive": "dev/macos/flutter_macos_1.18.0-dev.3.0-dev.zip",
      "sha256": "7f96bb3faac70774f521cdf3a906c808cfe4041192fb3fef984a10b06a7dc73f"
    }
  ]
}

```