### PR TITLE
Update jq-downloader for Mac M1

### DIFF
--- a/bin/jq-downloader
+++ b/bin/jq-downloader
@@ -9,12 +9,12 @@ get_jq_filename() {
     Darwin)
       case "$(uname -m)" in
         x86_64) echo jq-osx-amd64 ;;
+        arm64) echo jq-osx-amd64 ;;
     esac ;;
   esac
 }
 
 download_jq_if_not_exists() {
-  
   if [ ! -e "${jq}" ]
   then
     curl -sL "https://github.com/stedolan/jq/releases/latest/download/$(get_jq_filename)" -o "${jq}"


### PR DESCRIPTION
Fix https://github.com/oae/asdf-flutter/issues/16

Added line for M1 mac to jq-downloader to resolve jq installation failure.

```
/Users/mamoru/.asdf/plugins/flutter/bin/jq: line 1: Not: command not found
Cannot find the download url for the version: 1.22.3-stable
```