### PR TITLE
Remove echos with confuse asdf

### DIFF
--- a/bin/jq-downloader
+++ b/bin/jq-downloader
@@ -19,11 +19,9 @@ download_jq_if_not_exists() {
   jq_path="$(type -p jq || echo ${currentDir}/jq)"
 
   if [[ -z "$(type -p ${jq_path})" ]]; then
-    echo "jq does not exist in PATH. Downloading it."
     curl -sL "https://github.com/stedolan/jq/releases/latest/download/$(get_jq_filename)" -o "${jq_path}"
     chmod +x "${jq_path}"
   fi
 
   export JQ_BIN="${jq_path}"
-  echo "jq is now in ${JQ_BIN}"
 }


### PR DESCRIPTION
These print statements confuse asdf into listing the words of the
statement as versions instead of the versions themselves:

  $ asdf list all flutter
  jq
  is
  now
  in
  /usr/local/bin/jq

Fix this by removing these statements.