### PR TITLE
Added Troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ asdf plugin-add flutter
 ## Configure
 
 If you have problems with accessing to google, you can set the `FLUTTER_STORAGE_BASE_URL` environment variable to change it but structure must be same with Google. Default value is `https://storage.googleapis.com`.
+
+## Troubleshooting
+
+### Bad CPU type in executable
+
+Because this plugin uses [jq](https://github.com/stedolan/jq) you have to enable [Rosetta](https://support.apple.com/en-us/HT211861) to be able to execute non arm optimized software.
+
+Apple will prompt you to install Rosetta if you open a GUI application but not if you're using the terminal. Thus you have to enable Rosetta manually:
+
+```bash
+softwareupdate --install-rosetta
+```
+
+


### PR DESCRIPTION
Hey there, I've encountered the problem that I didn't have Rosetta installed on my new MacBook M1. After some research I found out that if you've never opened a GUI x86_64 application on the MacBooks with the M1 chip, you won't be asked to install rosetta.

After manually installing rosetta everything worked fine. Thus I've added a `Troubleshooting` section for other users of your plugin.