### PR TITLE
support install arm64 flutter sdk on macOS

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,8 +21,12 @@ install() {
   fi
   
   local escapedInstallVersion=$(echo $ASDF_INSTALL_VERSION | sed 's/\./\\\./g;s/\+/\\\+/g')
+  local arch="x64"
+  if [ "$(uname -s)" == "Darwin" ] && [ "$(uname -m)" == "arm64" ]; then
+    arch="arm64"
+  fi
 
-  local filePath=$(curl -sL "${versionListUrl}" | "${JQ_BIN}" -r --arg VERSION "${escapedInstallVersion}" '.releases[] | select((.version + "-" + .channel) | test("^v?" + $VERSION)) | .archive')
+  local filePath=$(curl -sL "${versionListUrl}" | "${JQ_BIN}" -r --arg VERSION "${escapedInstallVersion}" --arg ARCH "${arch}" '.releases[] | select((.version + "-" + .channel) | test("^v?" + $VERSION)) | select((has("dart_sdk_arch") | not) or (.dart_sdk_arch == $ARCH)) | .archive')
 
   if [ -z "${filePath}" ]; then
     echo "Cannot find the download url for the version: ${ASDF_INSTALL_VERSION}"


### PR DESCRIPTION
Fix problem with arm64 Flutter SDK being selected on **Intel macOS**.

```
$ uname -m
x86_64
$ asdf install flutter 2.12.0-4.1.pre-beta
curl: (3) URL using bad/illegal format or missing URL
tar: Error opening archive: Failed to open 'flutter_macos_arm64_2.12.0-4.1.pre-beta.zip'
```