### PR TITLE
Fix: unable to install any non-ARM flutter release on M1 macOS

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,12 +21,8 @@ install() {
   fi
   
   local escapedInstallVersion=$(echo $ASDF_INSTALL_VERSION | sed 's/\./\\\./g;s/\+/\\\+/g')
-  local arch="x64"
-  if [ "$(uname -s)" == "Darwin" ] && [ "$(uname -m)" == "arm64" ]; then
-    arch="arm64"
-  fi
 
-  local filePath=$(curl -sL "${versionListUrl}" | "${JQ_BIN}" -r --arg VERSION "${escapedInstallVersion}" --arg ARCH "${arch}" '.releases[] | select((.version + "-" + .channel) | test("^v?" + $VERSION)) | select((has("dart_sdk_arch") | not) or (.dart_sdk_arch == $ARCH)) | .archive')
+  local filePath=$(curl -sL "${versionListUrl}" | "${JQ_BIN}" -r --arg VERSION "${escapedInstallVersion}" '.releases[] | select((.version + "-" + .channel) | test("^v?" + $VERSION)) | .archive')
 
   if [ -z "${filePath}" ]; then
     echo "Cannot find the download url for the version: ${ASDF_INSTALL_VERSION}"

--- a/bin/install
+++ b/bin/install
@@ -21,8 +21,16 @@ install() {
   fi
   
   local escapedInstallVersion=$(echo $ASDF_INSTALL_VERSION | sed 's/\./\\\./g;s/\+/\\\+/g')
-
-  local filePath=$(curl -sL "${versionListUrl}" | "${JQ_BIN}" -r --arg VERSION "${escapedInstallVersion}" '.releases[] | select((.version + "-" + .channel) | test("^v?" + $VERSION)) | .archive')
+  local jsonResponse=$(curl -sL "${versionListUrl}" | "${JQ_BIN}" --arg VERSION "${escapedInstallVersion}" '.releases[] | select((.version + "-" + .channel) | test("^v?" + $VERSION))')
+  local jsonResponseLength=$(echo "${jsonResponse}" | jq -s 'length')
+  local filePath=$(echo "${jsonResponse}" | jq -r '.archive')
+  if [ "$(uname -s)" == "Darwin" ] && [ ${jsonResponseLength} -gt 1 ]; then
+    local arch="x64"
+    if [ "$(uname -m)" == "arm64" ]; then
+      arch="arm64"
+    fi
+    filePath=$(echo "${jsonResponse}" | jq -r --arg ARCH "${arch}" '. | select(.dart_sdk_arch == $ARCH) | .archive')
+  fi
 
   if [ -z "${filePath}" ]; then
     echo "Cannot find the download url for the version: ${ASDF_INSTALL_VERSION}"


### PR DESCRIPTION
Fix #27

I'm sorry for this bug 😢 