### PR TITLE
Fix: Install not working when jq is not already installed

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -22,14 +22,14 @@ install() {
   
   local escapedInstallVersion=$(echo $ASDF_INSTALL_VERSION | sed 's/\./\\\./g;s/\+/\\\+/g')
   local jsonResponse=$(curl -sL "${versionListUrl}" | "${JQ_BIN}" --arg VERSION "${escapedInstallVersion}" '.releases[] | select((.version + "-" + .channel) | test("^v?" + $VERSION))')
-  local jsonResponseLength=$(echo "${jsonResponse}" | jq -s 'length')
-  local filePath=$(echo "${jsonResponse}" | jq -r '.archive')
+  local jsonResponseLength=$(echo "${jsonResponse}" | "${JQ_BIN}" -s 'length')
+  local filePath=$(echo "${jsonResponse}" | "${JQ_BIN}" -r '.archive')
   if [ "$(uname -s)" == "Darwin" ] && [ ${jsonResponseLength} -gt 1 ]; then
     local arch="x64"
     if [ "$(uname -m)" == "arm64" ]; then
       arch="arm64"
     fi
-    filePath=$(echo "${jsonResponse}" | jq -r --arg ARCH "${arch}" '. | select(.dart_sdk_arch == $ARCH) | .archive')
+    filePath=$(echo "${jsonResponse}" | "${JQ_BIN}" -r --arg ARCH "${arch}" '. | select(.dart_sdk_arch == $ARCH) | .archive')
   fi
 
   if [ -z "${filePath}" ]; then


### PR DESCRIPTION
The `install` command tried to use the system native **jq** instead of the one downloaded by this plugin. This resulted in a crash when **jq** was not installed locally.