### PR TITLE
fixes #33: install from zip files

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -43,7 +43,13 @@ install() {
   mkdir -p "${ASDF_INSTALL_PATH}"
   cd "${ASDF_INSTALL_PATH}" || exit 1
   curl -OJL "${url}"
-  tar xf "${fileName}" --strip 1
+  if [ "${fileName##*.}" == "zip" ]; then
+    local tmpdir="$(mktemp -d)"
+    unzip -d "${tmpdir}" "${fileName}"
+    mv "${tmpdir}/flutter"/* "${ASDF_INSTALL_PATH}/"
+  else
+    tar xf "${fileName}" --strip 1
+  fi
   rm -f "${fileName}"
 }
 


### PR DESCRIPTION
I'm not sure why the MacOS builds are sometimes zip files, but this PR should handle those cases.

`unzip` doesn't have a `--strip` option like tar, so it has to unzip to a tmp directory and then move the files over.