### PR TITLE
update: Support no channel versioning

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -29,7 +29,9 @@ install() {
     if [ "$(uname -m)" == "arm64" ]; then
       arch="arm64"
     fi
-    filePath=$(echo "${jsonResponse}" | jq -r --arg ARCH "${arch}" '. | select(.dart_sdk_arch == $ARCH) | .archive')
+
+    channel=$(echo "$ASDF_INSTALL_VERSION" | grep -oE '(stable|beta|dev)$' || echo "stable")
+    filePath=$(echo "${jsonResponse}" | jq -r --arg ARCH "${arch}" --arg CHANNEL "${channel}" '. | select(.dart_sdk_arch == $ARCH and .channel == $CHANNEL) | .archive')
   fi
 
   if [ -z "${filePath}" ]; then


### PR DESCRIPTION
## Issue
Behavior of installing specific version without channel is unstable.
`asdf install flutter 3.10.0` will install beta channel. On the other hand, `asdf install flutter 3.7.12` will install stable channel.
It depends on the order of version list.

## Proposal
Install stable channel version if no channel specified.