### PR TITLE
fix: update repository and assets in jq-downloader

### DIFF
--- a/bin/jq-downloader
+++ b/bin/jq-downloader
@@ -4,12 +4,12 @@ get_jq_filename() {
   case "$(uname -s)" in
   Linux)
     case "$(uname -m)" in
-    x86_64) echo jq-linux64 ;;
+    x86_64) echo jq-linux-amd64 ;;
     esac ;;
   Darwin)
     case "$(uname -m)" in
-    x86_64) echo jq-osx-amd64 ;;
-    arm64) echo jq-osx-amd64 ;;
+    x86_64) echo jq-macos-amd64 ;;
+    arm64) echo jq-macos-arm64 ;;
     esac ;;
   esac
 }
@@ -19,7 +19,7 @@ download_jq_if_not_exists() {
   jq_path="$(type -p jq || echo ${currentDir}/jq)"
 
   if [[ -z "$(type -p ${jq_path})" ]]; then
-    curl -sL "https://github.com/stedolan/jq/releases/latest/download/$(get_jq_filename)" -o "${jq_path}"
+    curl -sL "https://github.com/jqlang/jq/releases/latest/download/$(get_jq_filename)" -o "${jq_path}"
     chmod +x "${jq_path}"
   fi
 


### PR DESCRIPTION
fixes #44 

The jq project now lives in another repo, more info in the last release notes ->  https://github.com/jqlang/jq/releases/tag/jq-1.7